### PR TITLE
Use fold to format output

### DIFF
--- a/hacker-quotes.plugin.zsh
+++ b/hacker-quotes.plugin.zsh
@@ -171,7 +171,7 @@ if [[ -o interactive ]] && [[ -o login || -n "${ZSH_HACKER_QUOTES_ENABLE_WHEN_IN
         "Peace comes from thinking.\n - N.S.A"
     )
 
-    printf '%b\n\n' "${_zp_hq_hacker_quotes[RANDOM % $#_zp_hq_hacker_quotes + 1]}"
+    printf '%b\n\n' "${_zp_hq_hacker_quotes[RANDOM % $#_zp_hq_hacker_quotes + 1]}" | fold -s -w $COLUMNS
     # release memory
     unset _zp_hq_hacker_quotes
 fi


### PR DESCRIPTION
I recommend piping the output of `printf` through `fold -s -w $COLUMNS`. It will cause the text to wrap at word breaks. `$COLUMNS` is updated by Zsh, and `fold -s -w` is part of the POSIX standard. I checked to make sure that the code will even work with BusyBox's version of `fold`.